### PR TITLE
Fixing squid: S1610 Abstract classes without fields should be converted to interfaces

### DIFF
--- a/library/src/main/java/io/github/meness/easyintro/IndicatorsContainerHeight.java
+++ b/library/src/main/java/io/github/meness/easyintro/IndicatorsContainerHeight.java
@@ -19,6 +19,6 @@ package io.github.meness.easyintro;
 /**
  * It's just a helper.
  */
-public abstract class IndicatorsContainerHeight {
-    public abstract void call(int height);
+public interface IndicatorsContainerHeight {
+      void call(int height);
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1610-”Abstract classes without fields should be converted to interfaces. "
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1610
 Please let me know if you have any questions.
Fevzi Ozgul