### PR TITLE
Fixing squid:2696 Instance methods should not write to "static" fields

### DIFF
--- a/library/src/main/java/io/github/meness/easyintro/EasyIntroSlidesInside.java
+++ b/library/src/main/java/io/github/meness/easyintro/EasyIntroSlidesInside.java
@@ -26,8 +26,8 @@ import java.util.List;
 public abstract class EasyIntroSlidesInside extends EasyIntroFragment {
     // first slide is the main one
     private static List<Fragment> mSlidesInside = new ArrayList<>();
-    private static int mCurrentSlideLocation = 0;
-    private static boolean mFirstInit;
+    private  int mCurrentSlideLocation = 0;
+    private  boolean mFirstInit;
 
     public final void withSlide(Fragment fragment) {
         mSlidesInside.add(fragment);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2696 - “Instance methods should not write to "static" fields”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2696
 Please let me know if you have any questions.
Fevzi Ozgul